### PR TITLE
Message_Image表修改

### DIFF
--- a/SQLs/create_tables.sql
+++ b/SQLs/create_tables.sql
@@ -169,8 +169,8 @@ INCREMENT BY 1
 CACHE 10;
 
 CREATE TABLE Message_Image(
-  message_image_id INTEGER PRIMARY KEY,
-  message_id INTEGER NOT NULL,
+  message_id INTEGER PRIMARY KEY,
+  message_image_count INTEGER NOT NULL,
   CONSTRAINT fk_message_image FOREIGN KEY
     (message_id) REFERENCES Message(message_id)
       ON DELETE CASCADE


### PR DESCRIPTION
修改后表内只剩下message_id和记录图片数量的count计数，不含图片的message不进入这个表。